### PR TITLE
Changes to compile with pandoc-1.9

### DIFF
--- a/src/Network/Gitit/Plugin/Tasks.hs
+++ b/src/Network/Gitit/Plugin/Tasks.hs
@@ -89,7 +89,7 @@ parsePara (Str "[":statusInline:Str "]":Space:rest) makeBlock content = do
     parseMeta task rest
   where
     parseMeta :: Task -> [Inline] -> Parser Task
-    parseMeta task all@(Str year:EnDash:Str month:EnDash:Str day:Space:rest) =
+    parseMeta task all@(Str year:Str "-":Str month:Str "-":Str day:Space:rest) =
       case parseTime defaultTimeLocale "%Y-%m-%d" (year ++ "-" ++ month ++ "-" ++ day) of
         Just date -> do
           status' <- updateStatusWithDate date (status task)


### PR DESCRIPTION
As you suggested changing `EnDash`  to `Str "-"` worked perfectly fine. Compiled with pandoc-1.9.1.2 and gitit-0.9.
